### PR TITLE
Making the need cert annotation value configurable

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -57,7 +57,7 @@ if [[ `go list -f {{.Incomplete}}` == "true" ]]; then
 
         mkdir -p /opt/app-root/src/bin
 
-        mv $GOPATH/bin/$BINARY_NAME /opt/app-root/src/bin/gobinary
+        mv $GOPATH/bin/$BINARY_NAME /opt/app-root/gobinary
 
         popd
 

--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -57,7 +57,7 @@ if [[ `go list -f {{.Incomplete}}` == "true" ]]; then
 
         mkdir -p /opt/app-root/src/bin
 
-        mv $GOPATH/bin/$BINARY_NAME /opt/app-root/src/bin/cert-operator
+        mv $GOPATH/bin/$BINARY_NAME /opt/app-root/src/bin/gobinary
 
         popd
 

--- a/pkg/stub/config.go
+++ b/pkg/stub/config.go
@@ -10,8 +10,8 @@ notifiers:
 package stub
 
 import (
-	"os"
 	"encoding/json"
+	"os"
 
 	config "github.com/micro/go-config"
 	"github.com/micro/go-config/source/env"
@@ -33,10 +33,11 @@ type GeneralConfig struct {
 }
 
 type AnnotationConfig struct {
-	Status       string `json:"status"`
-	StatusReason string `json:"status-reason"`
-	Expiry       string `json:"expiry"`
-	Format       string `json:"format"`
+	Status        string `json:"status"`
+	StatusReason  string `json:"status-reason"`
+	Expiry        string `json:"expiry"`
+	Format        string `json:"format"`
+	NeedCertValue string `json:"need-cert-value"`
 }
 
 const (
@@ -49,7 +50,8 @@ const (
         "status": "openshift.io/cert-ctl-status",
         "status-reason": "openshift.io/cert-ctl-status-reason",
         "expiry": "openshift.io/cert-ctl-expires",
-        "format": "openshift.io/cert-ctl-format"
+        "format": "openshift.io/cert-ctl-format",
+				"need-cert-value": "new"
       }
     },
     "provider": {
@@ -96,7 +98,7 @@ func getConfigFile() (configFile string) {
 func (c *Config) String() string {
 	out, err := json.Marshal(c)
 	if err != nil {
-			panic (err)
+		panic(err)
 	}
 	return string(out)
 }

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -28,19 +28,19 @@ func NewHandler(config Config) sdk.Handler {
 	}
 
 	switch config.Provider.Kind {
-		case "none":
-			logrus.Infof("None provider.")
-			provider = new(certs.NoneProvider)
-		case "self-signed":
-			logrus.Infof("Self Signed provider.")
-			provider = new(certs.SelfSignedProvider)
-		case "venafi":
-			logrus.Infof("Venafi Cert provider.")
-			provider = new(certs.VenafiProvider)
-		default:
-			panic("There was a problem detecting which provider to configure. \n" +
-				"\tProvider kind `" + config.Provider.Kind + "` is invalid. \n" +
-				config.String())
+	case "none":
+		logrus.Infof("None provider.")
+		provider = new(certs.NoneProvider)
+	case "self-signed":
+		logrus.Infof("Self Signed provider.")
+		provider = new(certs.SelfSignedProvider)
+	case "venafi":
+		logrus.Infof("Venafi Cert provider.")
+		provider = new(certs.VenafiProvider)
+	default:
+		panic("There was a problem detecting which provider to configure. \n" +
+			"\tProvider kind `" + config.Provider.Kind + "` is invalid. \n" +
+			config.String())
 	}
 	return &Handler{
 		config:   config,
@@ -71,7 +71,7 @@ func (h *Handler) handleRoute(route *v1.Route) error {
 		return nil
 	}
 
-	if route.ObjectMeta.Annotations[h.config.General.Annotations.Status] == "new" {
+	if route.ObjectMeta.Annotations[h.config.General.Annotations.Status] == h.config.General.Annotations.NeedCertValue {
 		// Notfiy of certificate awaiting creation
 		logrus.Infof("Found a route waiting for a cert : %v/%v",
 			route.ObjectMeta.Namespace,
@@ -117,7 +117,7 @@ func (h *Handler) handleService(service *corev1.Service) error {
 		return nil
 	}
 
-	if service.ObjectMeta.Annotations[h.config.General.Annotations.Status] == "new" {
+	if service.ObjectMeta.Annotations[h.config.General.Annotations.Status] == h.config.General.Annotations.NeedCertValue {
 		logrus.Infof("Found a service waiting for a cert : %v/%v",
 			service.ObjectMeta.Namespace,
 			service.ObjectMeta.Name)

--- a/test/config/custom-annotations.yaml
+++ b/test/config/custom-annotations.yaml
@@ -1,0 +1,7 @@
+general:
+  annotations:
+    status: myorg.io/cert-status
+    status-reason: myorg.io/cert-reason
+    expiry: myorg.io/cert-expires
+    format: myorg.io/cert-format
+    need-cert-value: need

--- a/test/config/self-signed.yaml
+++ b/test/config/self-signed.yaml
@@ -1,0 +1,2 @@
+provider:
+  kind: self-signed


### PR DESCRIPTION
This PR make the "new" string in the annotation configurable.

## To Test

use the following included config file:
```
export CERT_OP_CONFIG=$PWD/test/config/custom-annotations.yaml
export OPERATOR_NAME=cert-operator
operator-sdk up local
```

Then annotate some routes with:
```
oc annotate route myourte myorg.io/cert-status=need --overwrite
```

@Gl4di4torRr 