### PR TITLE
add error message to status reason and mark status as failed

### DIFF
--- a/pkg/certs/venafi.go
+++ b/pkg/certs/venafi.go
@@ -77,7 +77,7 @@ func (p *VenafiProvider) Provision(host string, validFrom string, validFor time.
 
 	c, err := vcert.NewClient(tppConfig)
 	if err != nil {
-		t.Fatalf("could not connect to endpoint: %s", err)
+		return KeyPair{}, NewCertError("could not connect to endpoint: " + err.Error())
 	}
 
 	enrollReq := &certificate.Request{
@@ -98,12 +98,12 @@ func (p *VenafiProvider) Provision(host string, validFrom string, validFor time.
 
 	err = c.GenerateRequest(nil, enrollReq)
 	if err != nil {
-		t.Fatalf("could not generate certificate request: %s", err)
+		return KeyPair{}, NewCertError("could not generate certificate request: " + err.Error())
 	}
 
 	requestID, err := c.RequestCertificate(enrollReq, "")
 	if err != nil {
-		t.Fatalf("could not submit certificate request: %s", err)
+		return KeyPair{}, NewCertError("could not submit certificate request: " + err.Error())
 	}
 	t.Printf("Successfully submitted certificate request. Will pickup certificate by ID %s", requestID)
 
@@ -113,7 +113,7 @@ func (p *VenafiProvider) Provision(host string, validFrom string, validFor time.
 	}
 	pcc, err := c.RetrieveCertificate(pickupReq)
 	if err != nil {
-		t.Fatalf("could not retrieve certificate using requestId %s: %s", requestID, err)
+		return KeyPair{}, NewCertError("could not retrieve certificate using requestId " + err.Error())
 	}
 
 	pcc.AddPrivateKey(enrollReq.PrivateKey, []byte(enrollReq.KeyPassword))

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -83,13 +83,13 @@ func (h *Handler) handleRoute(route *v1.Route) error {
 		h.notify(message)
 
 		// Retreive cert from provider
-		keyPair, errorMessage := h.getCert(route.Spec.Host)
+		keyPair, err := h.getCert(route.Spec.Host)
 
 		var routeCopy *v1.Route
 		routeCopy = route.DeepCopy()
-		if errorMessage != "" {
+		if err != nil {
 			routeCopy.ObjectMeta.Annotations[h.config.General.Annotations.Status] = "failed"
-			routeCopy.ObjectMeta.Annotations[h.config.General.Annotations.StatusReason] = errorMessage
+			routeCopy.ObjectMeta.Annotations[h.config.General.Annotations.StatusReason] = err.Error()
 		} else {
 			routeCopy.ObjectMeta.Annotations[h.config.General.Annotations.Status] = "no"
 		}
@@ -137,10 +137,10 @@ func (h *Handler) handleService(service *corev1.Service) error {
 		host := service.ObjectMeta.Name + "." + service.ObjectMeta.Namespace + ".svc.cluster.local"
 
 		// Retreive cert from provider
-		keyPair, errorMessage := h.getCert(host)
+		keyPair, err := h.getCert(host)
 
-		if errorMessage != "" {
-			logrus.Errorf(errorMessage)
+		if err != nil {
+			logrus.Errorf(err.Error())
 		}
 
 		var svcCopy *corev1.Service
@@ -163,7 +163,7 @@ func (h *Handler) handleService(service *corev1.Service) error {
 			Data: dm,
 		}
 
-		err := sdk.Create(certSec)
+		err = sdk.Create(certSec)
 		if err != nil {
 			logrus.Errorf("Failed to create secret: " + err.Error())
 			return err
@@ -208,7 +208,7 @@ func (h *Handler) notify(message string) {
 	}
 }
 
-func (h *Handler) getCert(host string) (certs.KeyPair, string) {
+func (h *Handler) getCert(host string) (certs.KeyPair, error) {
 	oneYear, timeErr := time.ParseDuration("8760h")
 	if timeErr != nil {
 		logrus.Errorf("Failed to parse time duratio during getCert: " + timeErr.Error())
@@ -221,9 +221,9 @@ func (h *Handler) getCert(host string) (certs.KeyPair, string) {
 		oneYear, false, 2048, "", h.config.Provider.Ssl)
 	if err != nil {
 		logrus.Errorf("Failed to provision key pair: " + err.Error())
-		return keyPair, err.Error()
+		return keyPair, err
 	}
-	return keyPair, ""
+	return keyPair, nil
 }
 
 // update route def

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -83,10 +83,16 @@ func (h *Handler) handleRoute(route *v1.Route) error {
 		h.notify(message)
 
 		// Retreive cert from provider
-		keyPair := h.getCert(route.Spec.Host)
+		keyPair, errorMessage := h.getCert(route.Spec.Host)
+
 		var routeCopy *v1.Route
 		routeCopy = route.DeepCopy()
-		routeCopy.ObjectMeta.Annotations[h.config.General.Annotations.Status] = "no"
+		if errorMessage != "" {
+			routeCopy.ObjectMeta.Annotations[h.config.General.Annotations.Status] = "failed"
+			routeCopy.ObjectMeta.Annotations[h.config.General.Annotations.StatusReason] = errorMessage
+		} else {
+			routeCopy.ObjectMeta.Annotations[h.config.General.Annotations.Status] = "no"
+		}
 		routeCopy.ObjectMeta.Annotations[h.config.General.Annotations.Expiry] = keyPair.Expiry.Format(timeFormat)
 
 		config := routeCopy.Spec.TLS
@@ -131,7 +137,11 @@ func (h *Handler) handleService(service *corev1.Service) error {
 		host := service.ObjectMeta.Name + "." + service.ObjectMeta.Namespace + ".svc.cluster.local"
 
 		// Retreive cert from provider
-		keyPair := h.getCert(host)
+		keyPair, errorMessage := h.getCert(host)
+
+		if errorMessage != "" {
+			logrus.Errorf(errorMessage)
+		}
 
 		var svcCopy *corev1.Service
 		svcCopy = service.DeepCopy()
@@ -198,7 +208,7 @@ func (h *Handler) notify(message string) {
 	}
 }
 
-func (h *Handler) getCert(host string) certs.KeyPair {
+func (h *Handler) getCert(host string) (certs.KeyPair, string) {
 	oneYear, timeErr := time.ParseDuration("8760h")
 	if timeErr != nil {
 		logrus.Errorf("Failed to parse time duratio during getCert: " + timeErr.Error())
@@ -211,8 +221,9 @@ func (h *Handler) getCert(host string) certs.KeyPair {
 		oneYear, false, 2048, "", h.config.Provider.Ssl)
 	if err != nil {
 		logrus.Errorf("Failed to provision key pair: " + err.Error())
+		return keyPair, err.Error()
 	}
-	return keyPair
+	return keyPair, ""
 }
 
 // update route def


### PR DESCRIPTION
@etsauer please take a look at this one... better error handling for venafi provider.

How to test:

Using the Venafi a provider create a route with hostname:
`my-test-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.mytest.com`

This will result in a hostname that exceeds the character limit and output failed as the status and the error message will be in the status reason.