### PR TITLE
Pcks12 service secret

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,7 +11,6 @@ required = [
   "sigs.k8s.io/controller-tools/pkg/crd/generator",
   "github.com/openshift/api/route/v1",
   "github.com/micro/go-config",
-  "gotest.tools/assert",
   "software.sslmate.com/src/go-pkcs12",
   "github.com/Venafi/vcert",
   "github.com/stretchr/testify/assert"

--- a/README.adoc
+++ b/README.adoc
@@ -88,6 +88,14 @@ provider:
   ssl: <true/false>
 ----
 
+=== Certificate Formats
+
+This operator currently supports the following certificate formats.
+
+.Supported Formats
+* [x] PEM - default
+* [x] PKCS12
+
 === Notifications
 
 This operator currently supports sending notifications via ChatOps. The following is the set of current and planned providers.
@@ -159,7 +167,7 @@ spec:
 
 === Create a Certificate for a Service (SSL-to-Pod)
 
-Annotate the service to tell the operator it needs a cert.  The default certificate format will be PEM unless you first create an annotation of format "openshift.io/cert-ctl-format"
+Annotate the service to tell the operator it needs a cert.  The default certificate format will be PEM unless you first create an annotation of "openshift.io/cert-ctl-format" with
 
 [source,bash]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -159,7 +159,7 @@ spec:
 
 === Create a Certificate for a Service (SSL-to-Pod)
 
-Annotate the service to tell the operator it needs a cert.
+Annotate the service to tell the operator it needs a cert.  The default certificate format will be PEM unless you first create an annotation of format "openshift.io/cert-ctl-format"
 
 [source,bash]
 ----
@@ -189,3 +189,15 @@ You'll also notice that the annotation on the service has changed.
 $ oc get service dotnet-example -o jsonpath='{.metadata.annotations.openshift\.io/cert-ctl-status}'
 secured
 ----
+
+=== Create a Certificate for a Service (SSL-to-Pod) PKCS12 format
+
+Annotate the service to tell the operator it needs a cert.  The default certificate format will be PEM unless you first create an annotation of format "openshift.io/cert-ctl-format"
+
+[source,bash]
+----
+oc annotate service dotnet-example openshift.io/cert-ctl-format=pkcs12 --overwrite
+oc annotate service dotnet-example openshift.io/cert-ctl-status=new --overwrite
+----
+
+You will notice two entries in the secret "tls.p12" and "tls-p12-secret.txt"

--- a/README.adoc
+++ b/README.adoc
@@ -92,7 +92,7 @@ provider:
 
 This operator currently supports the following certificate formats.
 
-.Supported Formats
+.[[supported-cert-formats]]Supported Formats
 * [x] PEM - default
 * [x] PKCS12
 
@@ -167,7 +167,7 @@ spec:
 
 === Create a Certificate for a Service (SSL-to-Pod)
 
-Annotate the service to tell the operator it needs a cert.  The default certificate format will be PEM unless you first create an annotation of "openshift.io/cert-ctl-format" with
+Annotate the service to tell the operator it needs a cert.  The default certificate format will be PEM unless you first create an annotation of "openshift.io/cert-ctl-format" with a <<supported-cert-formats,Supported Certificate Formats>> above.
 
 [source,bash]
 ----

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,6 @@ type AnnotationConfig struct {
 	Expiry        string `json:"expiry"`
 	Format        string `json:"format"`
 	NeedCertValue string `json:"need-cert-value"`
-	IncludePkcs12 string `json:"include-pkcs-12"`
 }
 
 const (
@@ -52,12 +51,11 @@ const (
         "status-reason": "openshift.io/cert-ctl-status-reason",
         "expiry": "openshift.io/cert-ctl-expires",
         "format": "openshift.io/cert-ctl-format",
-        "include-pkcs-12": "openshift.io/cert-ctl-pkcs-12",
         "need-cert-value": "new"
       }
     },
     "provider": {
-      "kind": "none",
+      "kind": "self-signed",
       "ssl": "false"
     }
   }`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,8 @@ type AnnotationConfig struct {
 	Expiry        string `json:"expiry"`
 	Format        string `json:"format"`
 	NeedCertValue string `json:"need-cert-value"`
+	PemFormat     string `json:"pem-format-value"`
+	Pkcs12Format  string `json:"pkcs12-format-value"`
 }
 
 const (
@@ -51,7 +53,9 @@ const (
         "status-reason": "openshift.io/cert-ctl-status-reason",
         "expiry": "openshift.io/cert-ctl-expires",
         "format": "openshift.io/cert-ctl-format",
-        "need-cert-value": "new"
+        "need-cert-value": "new",
+        "pem-format-value": "PEM",
+        "pkcs12-format-value": "PKCS12"
       }
     },
     "provider": {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ type AnnotationConfig struct {
 	Expiry        string `json:"expiry"`
 	Format        string `json:"format"`
 	NeedCertValue string `json:"need-cert-value"`
+	IncludePkcs12 string `json:"include-pkcs-12c"`
 }
 
 const (
@@ -51,7 +52,8 @@ const (
         "status-reason": "openshift.io/cert-ctl-status-reason",
         "expiry": "openshift.io/cert-ctl-expires",
         "format": "openshift.io/cert-ctl-format",
-				"need-cert-value": "new"
+        "include-pkcs-12": "openshift.io/cert-ctl-pkcs-12",
+        "need-cert-value": "new"
       }
     },
     "provider": {

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -141,8 +141,8 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		dm := make(map[string][]byte)
-		dm["app.crt"] = keyPair.Cert
-		dm["app.key"] = keyPair.Key
+		dm["tls.crt"] = keyPair.Cert
+		dm["tls.key"] = keyPair.Key
 
 		// see if a pcks12 secret was requested
 
@@ -157,8 +157,8 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 				return reconcile.Result{}, err
 			}
 
-			dm["app.p12"] = p12cert
-			dm["app-secret.txt"] = []byte(password)
+			dm["tls.p12"] = p12cert
+			dm["tls-p12-secret.txt"] = []byte(password)
 		}
 
 		// Create a secret

--- a/pkg/helpers/rand.go
+++ b/pkg/helpers/rand.go
@@ -1,0 +1,24 @@
+package helpers
+
+import (
+	"math/rand"
+	"time"
+)
+
+const charset = "abcdefghijklmnopqrstuvwxyz" +
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+var seededRand *rand.Rand = rand.New(
+	rand.NewSource(time.Now().UnixNano()))
+
+func StringWithCharset(length int, charset string) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func String(length int) string {
+	return StringWithCharset(length, charset)
+}

--- a/pkg/rand/rand_string.go
+++ b/pkg/rand/rand_string.go
@@ -1,4 +1,4 @@
-package helpers
+package rand
 
 import (
 	"math/rand"

--- a/test/e2e/cert_test.go
+++ b/test/e2e/cert_test.go
@@ -6,13 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/assert"
-	"gotest.tools/assert/cmp"
-
 	routev1 "github.com/openshift/api/route/v1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-	a "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,7 +80,7 @@ func routeBasicTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx
 		return err
 	}
 
-	assert.Assert(t, waitForAnnotation(t, f, exampleRoute, "openshift.io/cert-ctl-status", "secured"))
+	assert.Nil(t, waitForAnnotation(t, f, exampleRoute, "openshift.io/cert-ctl-status", "secured"))
 
 	return nil
 }
@@ -135,7 +132,7 @@ func serviceP12Test(t *testing.T, f *framework.Framework, ctx *framework.TestCtx
 	}
 
 	// Check the the annotation was set properly
-	assert.Assert(t, waitForAnnotation(t, f, exampleService, "openshift.io/cert-ctl-status", "secured"))
+	assert.Nil(t, waitForAnnotation(t, f, exampleService, "openshift.io/cert-ctl-status", "secured"))
 
 	// Verify that a secret was created
 	exampleSecret := &corev1.Secret{}
@@ -146,10 +143,10 @@ func serviceP12Test(t *testing.T, f *framework.Framework, ctx *framework.TestCtx
 
 	// Check that the secret is of the expected type and has values set
 	assert.Equal(t, exampleSecret.Type, corev1.SecretTypeTLS)
-	assert.Assert(t, cmp.Contains(exampleSecret.Data, "tls.crt"))
-	assert.Assert(t, cmp.Contains(exampleSecret.Data, "tls.key"))
-	assert.Assert(t, cmp.Contains(exampleSecret.Data, "tls.p12"))
-	assert.Assert(t, cmp.Contains(exampleSecret.Data, "tls-p12-secret.txt"))
+	assert.NotContains(t, exampleSecret.Data, "tls.crt")
+	assert.NotContains(t, exampleSecret.Data, "tls.key")
+	assert.Contains(t, exampleSecret.Data, "tls.p12")
+	assert.Contains(t, exampleSecret.Data, "tls-p12-secret.txt")
 
 	return nil
 }
@@ -201,7 +198,7 @@ func serviceBasicTest(t *testing.T, f *framework.Framework, ctx *framework.TestC
 	}
 
 	// Check the the annotation was set properly
-	assert.Assert(t, waitForAnnotation(t, f, exampleService, "openshift.io/cert-ctl-status", "secured"))
+	assert.Nil(t, waitForAnnotation(t, f, exampleService, "openshift.io/cert-ctl-status", "secured"))
 
 	// Verify that a secret was created
 	exampleSecret := &corev1.Secret{}
@@ -212,10 +209,10 @@ func serviceBasicTest(t *testing.T, f *framework.Framework, ctx *framework.TestC
 
 	// Check that the secret is of the expected type and has values set
 	assert.Equal(t, exampleSecret.Type, corev1.SecretTypeTLS)
-	assert.Assert(t, cmp.Contains(exampleSecret.Data, "tls.crt"))
-	assert.Assert(t, cmp.Contains(exampleSecret.Data, "tls.key"))
-	a.NotContains(t, exampleSecret.Data, "tls.p12")
-	a.NotContains(t, exampleSecret.Data, "tls-p12-secret.txt")
+	assert.Contains(t, exampleSecret.Data, "tls.crt")
+	assert.Contains(t, exampleSecret.Data, "tls.key")
+	assert.NotContains(t, exampleSecret.Data, "tls.p12")
+	assert.NotContains(t, exampleSecret.Data, "tls-p12-secret.txt")
 
 	return nil
 }


### PR DESCRIPTION
add the ability to specify an annotation on a service and have a p12 file and text file with keystore secret as part of the existing *-certificate secret.  This uses the conversion utilities in my previous PR to actually convert the PEMs to P12 as part of the secret.