### PR TITLE
Specify version of Venafi dependency

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -70,6 +70,10 @@ required = [
 [[constraint]]
   name = "github.com/micro/go-config"
   version = "0.7.0"
+  
+[[constraint]]
+  name = "github.com/Venafi/vcert"
+  version = "3.18.4"
 
 [prune]
   go-tests = true


### PR DESCRIPTION
4.x release of Venafi introduced breaking API changes, pegging to the latest 3.X release