### PR TITLE
Fix issue 47: Upgraded Packages to v0.8.1 of operator-sdk

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,5 @@
 # Force dep to vendor the code generators, which aren't imported just used at dev time.
 required = [
-  "k8s.io/code-generator/cmd/defaulter-gen",
   "k8s.io/code-generator/cmd/deepcopy-gen",
   "k8s.io/code-generator/cmd/conversion-gen",
   "k8s.io/code-generator/cmd/client-gen",
@@ -10,10 +9,8 @@ required = [
   "k8s.io/gengo/args",
   "sigs.k8s.io/controller-tools/pkg/crd/generator",
   "github.com/openshift/api/route/v1",
-  "github.com/micro/go-config",
-  "software.sslmate.com/src/go-pkcs12",
   "github.com/Venafi/vcert",
-  "github.com/stretchr/testify/assert"
+  "software.sslmate.com/src/go-pkcs12"
 ]
 
 [[override]]
@@ -31,7 +28,7 @@ required = [
 
 [[override]]
   name = "sigs.k8s.io/controller-tools"
-  version = "=v0.1.8"
+  revision = "9d55346c2bde73fb3326ac22eac2e5210a730207"
 
 [[override]]
   name = "k8s.io/api"
@@ -55,7 +52,7 @@ required = [
 
 [[override]]
   name = "github.com/coreos/prometheus-operator"
-  version = "=v0.26.0"
+  version = "=v0.29.0"
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"
@@ -64,13 +61,9 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  branch = "master" #osdk_branch_annotation
-  # version = "=v0.5.0" #osdk_version_annotation
+  # branch = "v0.8.x" #osdk_branch_annotation
+  version = "=v0.8.1" #osdk_version_annotation
 
-[[constraint]]
-  name = "github.com/micro/go-config"
-  version = "0.7.0"
-  
 [[constraint]]
   name = "github.com/Venafi/vcert"
   version = "4.1.0"

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ toc::[]
 
 == Prerequisites
 
-* link:https://github.com/operator-framework/operator-sdk/tree/v0.7.0[Operator SDK v0.7.0]
+* link:https://github.com/operator-framework/operator-sdk/tree/v0.8.1[Operator SDK v0.8.1]
 * link:https://golang.github.io/dep/docs/installation.html[Dep]
 
 == Installation


### PR DESCRIPTION
The current version of the cert-operator can no longer compiles against the latest version of the operator-sdk. As it is currently set to master, this will upgrade all required packages to the latest version for the operator-sdk. 